### PR TITLE
use libgdal-core

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,19 +11,19 @@ jobs:
       linux_64_r_base4.3:
         CONFIG: linux_64_r_base4.3
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_r_base4.4:
         CONFIG: linux_64_r_base4.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_r_base4.3:
         CONFIG: linux_aarch64_r_base4.3
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_r_base4.4:
         CONFIG: linux_aarch64_r_base4.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_r_base4.3.yaml
+++ b/.ci_support/linux_64_r_base4.3.yaml
@@ -19,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_64_r_base4.4.yaml
+++ b/.ci_support/linux_64_r_base4.4.yaml
@@ -19,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_aarch64_r_base4.3.yaml
+++ b/.ci_support/linux_aarch64_r_base4.3.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -23,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_aarch64_r_base4.4.yaml
+++ b/.ci_support/linux_aarch64_r_base4.4.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -23,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/osx_64_r_base4.3.yaml
+++ b/.ci_support/osx_64_r_base4.3.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_64_r_base4.4.yaml
+++ b/.ci_support/osx_64_r_base4.4.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_arm64_r_base4.3.yaml
+++ b/.ci_support/osx_arm64_r_base4.3.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/osx_arm64_r_base4.4.yaml
+++ b/.ci_support/osx_arm64_r_base4.4.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win or ppc64le]
-  number: 2
+  number: 3
   rpaths:
     - lib/R/lib/
     - lib/
@@ -41,15 +41,12 @@ requirements:
   host:
     - r-base
     - r-rcpp >=1.0_10
-    - libgdal
+    - libgdal-core
     - proj
     - geos
   run:
     - r-base
     - r-rcpp >=1.0_10
-    - libgdal
-    - proj
-    - geos
 
 test:
   commands:


### PR DESCRIPTION
As suggested in https://github.com/conda-forge/r-sf-feedstock/issues/137, it seems that we only need `libgdal-core` instead of the full `libgdal` with all the plugins.  Switching `libgdal-core` would significantly reduce the dependency footprint of `r-terra`, which is currently quite heavy, even though it seems `r-terra` itself only uses functionality from `libgdal-core`.